### PR TITLE
Allow relative calculations ("ago" and "from now")

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ pub fn parse(input: &str) -> IResult<&str, DateMath> {
             ),
             |(from, to)| DateMath::DateDiff(from, to),
         ),
+        map(period_operation::parse_relative, |(period_op, rest)| {
+            DateMath::StartWithPeriods(CalculatedDate::Today, period_op, rest)
+        }),
         map(calculated_date::parse, DateMath::Start),
         map(
             pair(period::parse, many0(period_operation::parse)),
@@ -116,6 +119,15 @@ mod tests {
                 CalculatedDate::Raw(NaiveDate::from_ymd_opt(2021, 1, 2).unwrap()),
                 PeriodOp::Add(Period::Week(15)),
                 vec![]
+            )
+        );
+
+        assert_eq!(
+            parse("2 weeks and 1 day ago").unwrap().1,
+            DateMath::StartWithPeriods(
+                CalculatedDate::Today,
+                PeriodOp::Subtract(Period::Week(2)),
+                vec![PeriodOp::Subtract(Period::Day(1))]
             )
         );
 

--- a/src/period.rs
+++ b/src/period.rs
@@ -8,7 +8,7 @@ use nom::{
     IResult,
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Period {
     Day(usize),
     Week(usize),

--- a/src/period_operation.rs
+++ b/src/period_operation.rs
@@ -3,9 +3,10 @@ use chrono::NaiveDate;
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    character::complete::space0,
+    character::complete::{space0, space1},
     combinator::map,
-    sequence::{preceded, terminated},
+    multi::many1,
+    sequence::{delimited, pair, preceded, separated_pair, terminated},
     IResult,
 };
 
@@ -40,6 +41,66 @@ pub fn parse(input: &str) -> IResult<&str, PeriodOp> {
     )(input)
 }
 
+fn build_period_op_pair<F>(
+    period: Period,
+    rest: Vec<Period>,
+    builder: F,
+) -> (PeriodOp, Vec<PeriodOp>)
+where
+    F: Fn(Period) -> PeriodOp,
+{
+    (
+        builder(period),
+        rest.into_iter().map(builder).collect::<Vec<PeriodOp>>(),
+    )
+}
+
+pub fn parse_relative(input: &str) -> IResult<&str, (PeriodOp, Vec<PeriodOp>)> {
+    let (input, (period, rest)) = parse_sentence(input)?;
+
+    let result = alt((
+        map(tag(" ago"), |_| {
+            build_period_op_pair(period, rest.clone(), PeriodOp::Subtract)
+        }),
+        map(tag(" from now"), |_| {
+            build_period_op_pair(period, rest.clone(), PeriodOp::Add)
+        }),
+    ))(input);
+
+    result
+}
+
+fn period_and_comma(input: &str) -> IResult<&str, Period> {
+    terminated(period::parse, tag(","))(input)
+}
+
+fn parse_sentence(input: &str) -> IResult<&str, (Period, Vec<Period>)> {
+    let comma_delimited = map(
+        separated_pair(
+            pair(period_and_comma, many1(preceded(space1, period_and_comma))),
+            delimited(space1, tag("and"), space1),
+            period::parse,
+        ),
+        |((period, mut rest), last)| {
+            rest.extend([last]);
+            (period, rest)
+        },
+    );
+
+    let single_and = map(
+        separated_pair(
+            period::parse,
+            delimited(space1, tag("and"), space1),
+            period::parse,
+        ),
+        |(period, other)| (period, vec![other]),
+    );
+
+    let single = map(period::parse, |period| (period, vec![]));
+
+    alt((comma_delimited, single_and, single))(input)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -67,6 +128,67 @@ mod tests {
         assert_eq!(
             parse("   -    3 days").unwrap().1,
             PeriodOp::Subtract(Period::Day(3))
+        );
+    }
+
+    #[test]
+    fn test_human_subtract() {
+        assert_eq!(
+            parse_relative("3 days ago").unwrap().1,
+            (PeriodOp::Subtract(Period::Day(3)), Vec::new())
+        );
+
+        assert_eq!(
+            parse_relative("12 years ago").unwrap().1,
+            (PeriodOp::Subtract(Period::Year(12)), Vec::new())
+        );
+    }
+
+    #[test]
+    fn test_human_add() {
+        assert_eq!(
+            parse_relative("3 days from now").unwrap().1,
+            (PeriodOp::Add(Period::Day(3)), Vec::new())
+        );
+
+        assert_eq!(
+            parse_relative("12 weeks from now").unwrap().1,
+            (PeriodOp::Add(Period::Week(12)), Vec::new())
+        );
+    }
+
+    #[test]
+    fn test_human_pair() {
+        assert_eq!(
+            parse_relative("3 days and 1 week ago").unwrap().1,
+            (
+                PeriodOp::Subtract(Period::Day(3)),
+                vec![PeriodOp::Subtract(Period::Week(1))]
+            )
+        );
+    }
+
+    #[test]
+    fn test_human_sentence() {
+        assert_eq!(
+            parse_sentence("1 year, 2 months, and 3 days").unwrap().1,
+            (Period::Year(1), vec![Period::Month(2), Period::Day(3)])
+        );
+    }
+
+    #[test]
+    fn test_human_multiple() {
+        assert_eq!(
+            parse_relative("1 year, 2 months, and 3 days from now")
+                .unwrap()
+                .1,
+            (
+                PeriodOp::Add(Period::Year(1)),
+                vec![
+                    PeriodOp::Add(Period::Month(2)),
+                    PeriodOp::Add(Period::Day(3))
+                ]
+            )
         );
     }
 }


### PR DESCRIPTION
What?
=====

This introduces two modifiers, "ago" and "from now", for chaining one or
more calculated durations together, e.g.

2 weeks from now
1 week and 2 days ago
1 year, 6 weeks, and 2 days ago