### PR TITLE
Introduce ParseResult to make matching parse outcomes more ergonomic

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::parse;
+use crate::{parse, ParseResult};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -9,13 +9,13 @@ struct Flags {
 pub fn run() {
     let flags = Flags::from_args();
 
-    match parse(&flags.value) {
-        Ok(("", math)) => println!("{}", math.compute()),
-        Ok((unparsed, math)) => {
+    match parse(&flags.value).into() {
+        ParseResult::Success(math) => println!("{}", math.compute()),
+        ParseResult::PartialSuccess(math, unparsed) => {
             eprintln!("Unparsed input: '{}'", unparsed);
-            println!("{}", math.compute())
+            println!("{}", math.compute());
         }
-        Err(e) => {
+        ParseResult::Error(e) => {
             eprintln!("{}", e);
             std::process::exit(1)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,23 @@ impl DateMath {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub enum ParseResult<'a> {
+    Success(DateMath),
+    PartialSuccess(DateMath, &'a str),
+    Error(nom::Err<nom::error::Error<&'a str>>),
+}
+
+impl<'a> From<IResult<&'a str, DateMath>> for ParseResult<'a> {
+    fn from(result: IResult<&'a str, DateMath>) -> Self {
+        match result {
+            Ok(("", math)) => ParseResult::Success(math),
+            Ok((unparsed, math)) => ParseResult::PartialSuccess(math, unparsed),
+            Err(e) => ParseResult::Error(e),
+        }
+    }
+}
+
 pub fn parse(input: &str) -> IResult<&str, DateMath> {
     alt((
         map(


### PR DESCRIPTION
What?
=====

Rather than be concerned with the meaning of the first value of the
tuple when parsing (`&str`), this introduces a new type, `ParseResult`,
which provides more context around possible parsing outcomes.