### PR TITLE
Allow overriding the concept of "today" with an ENV variable

### DIFF
--- a/src/calculated_date.rs
+++ b/src/calculated_date.rs
@@ -15,12 +15,12 @@ pub enum CalculatedDate {
 }
 
 impl CalculatedDate {
-    pub fn calculate(&self) -> NaiveDate {
+    pub fn calculate(&self, today: NaiveDate) -> NaiveDate {
         match self {
             CalculatedDate::Raw(v) => *v,
-            CalculatedDate::Today => chrono::Local::today().naive_local(),
-            CalculatedDate::Yesterday => chrono::Local::today().naive_local() - Duration::days(1),
-            CalculatedDate::Tomorrow => chrono::Local::today().naive_local() + Duration::days(1),
+            CalculatedDate::Today => today,
+            CalculatedDate::Yesterday => today - Duration::days(1),
+            CalculatedDate::Tomorrow => today + Duration::days(1),
         }
     }
 }
@@ -71,27 +71,19 @@ fn parse_partial_date(value: &str) -> Option<NaiveDate> {
 mod tests {
     use super::*;
 
+    fn parse_and_calculate(value: &str, today: NaiveDate) -> NaiveDate {
+        parse(value).unwrap().1.calculate(today)
+    }
+
     #[test]
     fn test_date_relative() {
-        assert_eq!(
-            parse("today").unwrap().1.calculate(),
-            chrono::Local::today().naive_local()
-        );
+        let date = NaiveDate::from_ymd_opt(2022, 1, 31).unwrap();
+        let one_day = Duration::days(1);
 
-        assert_eq!(
-            parse("now").unwrap().1.calculate(),
-            chrono::Local::today().naive_local()
-        );
-
-        assert_eq!(
-            parse("yesterday").unwrap().1.calculate(),
-            chrono::Local::today().naive_local() - Duration::days(1)
-        );
-
-        assert_eq!(
-            parse("tomorrow").unwrap().1.calculate(),
-            chrono::Local::today().naive_local() + Duration::days(1)
-        );
+        assert_eq!(parse_and_calculate("today", date), date);
+        assert_eq!(parse_and_calculate("now", date), date);
+        assert_eq!(parse_and_calculate("yesterday", date), date - one_day);
+        assert_eq!(parse_and_calculate("tomorrow", date), date + one_day);
     }
 
     #[test]

--- a/src/calculated_date.rs
+++ b/src/calculated_date.rs
@@ -38,7 +38,7 @@ pub fn parse(input: &str) -> IResult<&str, CalculatedDate> {
     ))(input)
 }
 
-fn parse_date(value: &str) -> Option<NaiveDate> {
+pub(crate) fn parse_date(value: &str) -> Option<NaiveDate> {
     let value = value.trim();
     NaiveDate::parse_from_str(value, "%Y-%m-%d")
         .or(NaiveDate::parse_from_str(value, "%h %d, %Y"))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
-use crate::{parse, ParseResult};
+use crate::{calculated_date, parse, ParseResult};
+use chrono::NaiveDate;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -8,7 +9,7 @@ struct Flags {
 
 pub fn run() {
     let flags = Flags::from_args();
-    let today = chrono::Local::today().naive_local();
+    let today = today_from_env().unwrap_or(chrono::Local::today().naive_local());
 
     match parse(&flags.value).into() {
         ParseResult::Success(math) => println!("{}", math.compute(today)),
@@ -21,4 +22,10 @@ pub fn run() {
             std::process::exit(1)
         }
     }
+}
+
+fn today_from_env() -> Option<NaiveDate> {
+    std::env::var("TODAY")
+        .ok()
+        .and_then(|v| calculated_date::parse_date(&v))
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,12 +8,13 @@ struct Flags {
 
 pub fn run() {
     let flags = Flags::from_args();
+    let today = chrono::Local::today().naive_local();
 
     match parse(&flags.value).into() {
-        ParseResult::Success(math) => println!("{}", math.compute()),
+        ParseResult::Success(math) => println!("{}", math.compute(today)),
         ParseResult::PartialSuccess(math, unparsed) => {
             eprintln!("Unparsed input: '{}'", unparsed);
-            println!("{}", math.compute());
+            println!("{}", math.compute(today));
         }
         ParseResult::Error(e) => {
             eprintln!("{}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,19 +50,19 @@ impl From<NaiveDate> for ComputeOutcome {
 }
 
 impl DateMath {
-    pub fn compute(&self) -> ComputeOutcome {
+    pub fn compute(&self, today: NaiveDate) -> ComputeOutcome {
         match self {
             DateMath::DateDiff(from, to) => ComputeOutcome::DifferenceInDays(
-                (from.calculate() - to.calculate())
+                (from.calculate(today) - to.calculate(today))
                     .num_days()
                     .abs()
                     .try_into()
                     .unwrap(),
             ),
-            DateMath::Start(v) => v.calculate().into(),
+            DateMath::Start(v) => v.calculate(today).into(),
             DateMath::StartWithPeriods(v, base, rest) => rest
                 .iter()
-                .fold(base.apply(v.calculate()), |acc, x| x.apply(acc))
+                .fold(base.apply(v.calculate(today)), |acc, x| x.apply(acc))
                 .into(),
             DateMath::Periods(base, rest) => rest
                 .iter()
@@ -221,7 +221,7 @@ mod tests {
                 PeriodOp::Subtract(Period::Day(1)),
             ],
         )
-        .compute();
+        .compute(date(2022, 1, 31));
 
         assert_eq!(
             result,
@@ -235,7 +235,7 @@ mod tests {
             CalculatedDate::Raw(date(2021, 3, 31)),
             CalculatedDate::Raw(date(2021, 3, 24)),
         )
-        .compute();
+        .compute(date(2022, 1, 31));
 
         assert_eq!("7 days", result.to_string());
     }
@@ -246,7 +246,7 @@ mod tests {
             CalculatedDate::Raw(date(2021, 3, 31)),
             CalculatedDate::Raw(date(2021, 3, 31)),
         )
-        .compute();
+        .compute(date(2022, 1, 31));
 
         assert_eq!("0 days", result.to_string());
     }
@@ -257,7 +257,7 @@ mod tests {
             CalculatedDate::Raw(date(2021, 3, 31)),
             CalculatedDate::Raw(date(2021, 3, 30)),
         )
-        .compute();
+        .compute(date(2022, 1, 31));
 
         assert_eq!("1 day", result.to_string());
     }
@@ -268,7 +268,7 @@ mod tests {
             CalculatedDate::Raw(date(2021, 3, 24)),
             CalculatedDate::Raw(date(2021, 3, 31)),
         )
-        .compute();
+        .compute(date(2022, 1, 31));
 
         assert_eq!("7 days", result.to_string());
     }


### PR DESCRIPTION
What?
=====

This allows for overriding the notion of "today" by setting the environment
variable TODAY, e.g.

```sh
TODAY=2020-02-28 date-math 'tomorrow'
> 2020-02-29
```