### PR TITLE
Fix dates with dashes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@ mod tests {
             "yesterday",
             "tomorrow",
             "2 weeks ago",
+            "2022-01-20",
             "2 weeks from now",
             "two weeks from tomorrow",
             "1 week and 2 days ago",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod calculated_date;
 pub mod cli;
+mod parser_utils;
 mod period;
 mod period_operation;
 mod relative_period;

--- a/src/parser_utils.rs
+++ b/src/parser_utils.rs
@@ -1,0 +1,9 @@
+use nom::{
+    character::complete::digit1,
+    combinator::{map_res, recognize},
+    IResult,
+};
+
+pub(crate) fn parse_digits<T: std::str::FromStr>(input: &str) -> IResult<&str, T> {
+    map_res(recognize(digit1), str::parse)(input)
+}

--- a/src/period.rs
+++ b/src/period.rs
@@ -1,9 +1,10 @@
+use crate::parser_utils::*;
 use chrono::Duration;
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    character::complete::{digit1, space1},
-    combinator::{map_res, opt, recognize, value},
+    character::complete::space1,
+    combinator::{map_res, opt, value},
     sequence::{pair, terminated},
     IResult,
 };
@@ -30,7 +31,7 @@ impl Period {
 pub fn parse(input: &str) -> IResult<&str, Period> {
     map_res(
         pair(
-            terminated(alt((parse_usize, parse_written_number)), space1),
+            terminated(alt((parse_digits, parse_written_number)), space1),
             terminated(
                 alt((tag("day"), tag("week"), tag("month"), tag("year"))),
                 opt(tag("s")),
@@ -44,10 +45,6 @@ pub fn parse(input: &str) -> IResult<&str, Period> {
             _ => Err("unable to parse duration"),
         },
     )(input)
-}
-
-fn parse_usize(input: &str) -> IResult<&str, usize> {
-    map_res(recognize(digit1), str::parse)(input)
 }
 
 fn parse_written_number(input: &str) -> IResult<&str, usize> {


### PR DESCRIPTION
What?
=====

This fixes a bug where unit-testing parsing dates in the format YYYY-MM-DD
worked correctly but didn't parse within the broader context due to how the
parser consumed data (consuming text until encountering a dash or plus
symbol).